### PR TITLE
add -Wno-address-of-packed-member for uboot to fix GCC 9 error

### DIFF
--- a/u-boot/default.nix
+++ b/u-boot/default.nix
@@ -26,6 +26,8 @@ buildUBoot rec {
 
   defconfig = "roc-rk3399-pc_defconfig";
 
+  NIX_CFLAGS_COMPILE = "-Wno-address-of-packed-member"; # Fails on gcc9
+
   extraMakeFlags = [
     "all"
   ]


### PR DESCRIPTION
Fixes #2:
```
disk/part_efi.c: In function 'gpt_verify_partitions':
disk/part_efi.c:753:49: error: taking address of packed member of 'struct _gpt_entry' may result in an unaligned pointer value [-Werror=address-of-packed-member]
  753 |   gpt_convert_efi_name_to_char(efi_str, gpt_e[i].partition_name,
      |  
```